### PR TITLE
feat: add git metadata enrichment and fallback ownership

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,98 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type BlameInfo struct {
+	Hash   string
+	Author string
+	Date   time.Time
+}
+
+func GetBlame(filePath string) (map[int]BlameInfo, error) {
+
+	if !isGitRepo(filepath.Dir(filePath)) {
+		return nil, os.ErrNotExist
+	}
+
+	cmd := exec.Command("git", "blame", "--line-porcelain", filePath)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	result := make(map[int]BlameInfo)
+	scanner := bufio.NewScanner(&out)
+
+	var currentHash string
+	var currentAuthor string
+	var currentDate time.Time
+	var currentLine int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// In git blame --line-porcelain, the actual source code line
+		// always starts with a literal tab character.
+		if strings.HasPrefix(line, "\t") {
+			result[currentLine] = BlameInfo{
+				Hash:   currentHash,
+				Author: currentAuthor,
+				Date:   currentDate,
+			}
+			continue
+		}
+
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		key := parts[0]
+
+		// Standard SHA-1 hashes are 40 characters.
+		if len(key) == 40 {
+			currentHash = key
+			fields := strings.Fields(parts[1])
+			if len(fields) >= 2 {
+				if l, err := strconv.Atoi(fields[1]); err == nil {
+					currentLine = l
+				}
+			}
+			continue
+		}
+
+		switch key {
+		case "author":
+			currentAuthor = parts[1]
+		case "author-time":
+			if ts, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+				currentDate = time.Unix(ts, 0)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func isGitRepo(dir string) bool {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -4,18 +4,22 @@ import "time"
 
 // DebtBomb represents a technical debt item found in the codebase
 type DebtBomb struct {
-	ID        string    `json:"id"`
-	File      string    `json:"file"`
-	Line      int       `json:"line"`
-	Expire    time.Time `json:"expire"`
-	Owner     string    `json:"owner,omitempty"`
-	Ticket    string    `json:"ticket,omitempty"`
-	Reason    string    `json:"reason,omitempty"`
-	Severity  string    `json:"severity,omitempty"`
-	RawText   string    `json:"rawText"`
-	Snippet   string    `json:"snippet"`
+	ID       string    `json:"id"`
+	File     string    `json:"file"`
+	Line     int       `json:"line"`
+	Expire   time.Time `json:"expire"`
+	Owner    string    `json:"owner,omitempty"`
+	Ticket   string    `json:"ticket,omitempty"`
+	Reason   string    `json:"reason,omitempty"`
+	Severity string    `json:"severity,omitempty"`
+	RawText  string    `json:"rawText"`
+	Snippet  string    `json:"snippet"`
 
-	IsExpired bool      `json:"isExpired"`
+	IsExpired bool `json:"isExpired"`
+
+	GitAuthor  string    `json:"gitAuthor,omitempty"`
+	CommitHash string    `json:"commitHash,omitempty"`
+	CommitDate time.Time `json:"commitDate,omitempty"`
 }
 
 // DebtEvent represents a change in state of a DebtBomb


### PR DESCRIPTION
## Description
This PR integrates `git blame` functionality to automatically enrich DebtBombs with accountability metadata. It also introduces a smart fallback mechanism to assign ownership based on git history when no explicit owner is provided in the comment.

## Changes
- **New `internal/git` Package**:
  - Implements `GetBlame` using `git blame --line-porcelain` to retrieve commit hash, author, and date.
  - **Thread-Safety**: The package is stateless and designed for concurrent access without global locks.
- **Engine Updates**:
  - **Parallel Execution**: Git enrichment is performed concurrently within the existing worker pool during the file scanning phase, ensuring high performance for large repositories.
  - **Fallback Logic**: If a `@debtbomb` comment lacks an explicit `owner=...`, the system automatically defaults the owner to the git author of that line.
- **Model Updates**:
  - Added `GitAuthor`, `CommitHash`, and `CommitDate` fields to the `DebtBomb` struct.

## Usage
No new CLI flags are required. The tool now automatically:
1. Detects if it's running in a git repository.
2. Enriches findings with git metadata in the JSON output.
3. Uses the git author as the `owner` if one is not specified.

## Verification
- Verified manually in a dummy project (TS/JS environment).
- Confirmed that explicit owners (e.g., `owner=jdoe`) take precedence over git authors.
- Confirmed that parallel execution works correctly and produces accurate results.

closes #1 